### PR TITLE
Introduce auctionTimeApprove field

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -38,6 +38,7 @@ type SellerAuction @entity {
   seller: Bytes
   auctionTimeStart: BigInt
   auctionTimeEnd: BigInt
+  auctionTimeApprove: BigInt
   contractTimeStart: BigInt
   contractTimeEnd: BigInt
   priceStart: BigInt
@@ -56,7 +57,7 @@ type BuyerCampaign @entity {
   buyer: Bytes
   uri: String
   cumulativeVolumeUSDC: BigInt!
-  # sellerAuctions: [SellerAuction!] @derivedFrom(field: "buyerCampaigns")
+  sellerAuctions: [SellerAuction!] @derivedFrom(field: "buyerCampaigns")
   contracts: [Contract!] @derivedFrom(field: "buyerCampaign")
 }
 

--- a/src/ZestyMarketUSDC.ts
+++ b/src/ZestyMarketUSDC.ts
@@ -73,6 +73,7 @@ export function handleSellerAuctionCreate(event: SellerAuctionCreate): void {
   entity.seller = event.params.seller;
   entity.auctionTimeStart = event.params.auctionTimeStart;
   entity.auctionTimeEnd = event.params.auctionTimeEnd;
+  entity.auctionTimeApprove = new BigInt(0);
   entity.contractTimeStart = event.params.contractTimeStart;
   entity.contractTimeEnd = event.params.contractTimeEnd;
   entity.priceStart = event.params.priceStart;
@@ -180,6 +181,7 @@ export function handleSellerAuctionBuyerCampaignApprove(
 
         entity.pricePending = new BigInt(0);
         entity.priceEnd = event.params.priceEnd;
+        entity.auctionTimeApprove = event.block.timestamp;
 
         entity.save();
       }


### PR DESCRIPTION
`contractTimeStart` field can be misleading since a buyer will need to approve the auctions before the contract really starts. There is a need for a separate field `auctionTimeApprove` which denotes the time where the contract actually starts.

So the actual `contractTimeStart` is as follows:
```
if auctionTimeApprove > contractTimeStart:
    contractTimeStart = auctionTimeApprove
else:
    contractTimeStart = contractTimeStart
```